### PR TITLE
Changing names of DTOs to Data instead of VM

### DIFF
--- a/source/backend/Acerola.Application/DTO/AccountData.cs
+++ b/source/backend/Acerola.Application/DTO/AccountData.cs
@@ -1,13 +1,13 @@
-﻿namespace Acerola.Application.ViewModels
+﻿namespace Acerola.Application.DTO
 {
     using System;
     using System.Collections.Generic;
 
-    public class AccountVM
+    public class AccountData
     {
         public Guid AccountId { get; set; }
         public Guid CustomerId { get; set; }
         public double CurrentBalance { get; set; }
-        public List<TransactionVM> Transactions { get; set; }
+        public List<TransactionData> Transactions { get; set; }
     }
 }

--- a/source/backend/Acerola.Application/DTO/CustomerData.cs
+++ b/source/backend/Acerola.Application/DTO/CustomerData.cs
@@ -1,8 +1,8 @@
-﻿namespace Acerola.Application.ViewModels
+﻿namespace Acerola.Application.DTO
 {
     using System;
 
-    public class CustomerVM
+    public class CustomerData
     {
         public Guid CustomerId { get; set; }
         public string Personnummer { get; set; }

--- a/source/backend/Acerola.Application/DTO/TransactionData.cs
+++ b/source/backend/Acerola.Application/DTO/TransactionData.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Acerola.Application.ViewModels
+namespace Acerola.Application.DTO
 {
-    public class TransactionVM
+    public class TransactionData
     {
         public string Description { get; set; }
         public double Amount { get; set; }

--- a/source/backend/Acerola.Application/Queries/IAccountsQueries.cs
+++ b/source/backend/Acerola.Application/Queries/IAccountsQueries.cs
@@ -1,14 +1,14 @@
 ﻿namespace Acerola.Application.Queries
 {
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public interface IAccountsQueries
     {
-        Task<AccountVM> GetAccount(Guid id);
-        Task<IEnumerable<AccountVM>> GetAll();
-        Task<IEnumerable<AccountVM>> Get(Guid customerId);
+        Task<AccountData> GetAccount(Guid id);
+        Task<IEnumerable<AccountData>> GetAll();
+        Task<IEnumerable<AccountData>> Get(Guid customerId);
     }
 }

--- a/source/backend/Acerola.Application/Queries/ICustomersQueries.cs
+++ b/source/backend/Acerola.Application/Queries/ICustomersQueries.cs
@@ -1,13 +1,13 @@
 ﻿namespace Acerola.Application.Queries
 {
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public interface ICustomersQueries
     {
-        Task<CustomerVM> GetCustomer(Guid id);
-        Task<IEnumerable<CustomerVM>> GetAll();
+        Task<CustomerData> GetCustomer(Guid id);
+        Task<IEnumerable<CustomerData>> GetAll();
     }
 }

--- a/source/backend/Acerola.Infrastructure/AutoMapper/AccountsProfile.cs
+++ b/source/backend/Acerola.Infrastructure/AutoMapper/AccountsProfile.cs
@@ -1,0 +1,30 @@
+﻿using Acerola.Application.DTO;
+using Acerola.Domain.Accounts;
+using AutoMapper;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Acerola.Infrastructure.AutoMapper
+{
+    public class AccountsProfile : Profile
+    {
+        public AccountsProfile()
+        {
+            CreateMap<Account, AccountData>()
+                    .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.Id))
+                    .ForMember(dest => dest.CurrentBalance, opt => opt.MapFrom(src => src.CurrentBalance.Value))
+                    .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.CustomerId));
+
+            CreateMap<Debit, TransactionData>()
+                .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.Value))
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+                .ForMember(dest => dest.TransactionDate, opt => opt.MapFrom(src => src.TransactionDate));
+
+            CreateMap<Credit, TransactionData>()
+                .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.Value))
+                .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+                .ForMember(dest => dest.TransactionDate, opt => opt.MapFrom(src => src.TransactionDate));
+        }
+    }
+}

--- a/source/backend/Acerola.Infrastructure/AutoMapper/CustomersProfile.cs
+++ b/source/backend/Acerola.Infrastructure/AutoMapper/CustomersProfile.cs
@@ -1,0 +1,20 @@
+﻿using Acerola.Application.DTO;
+using Acerola.Domain.Customers;
+using AutoMapper;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Acerola.Infrastructure.AutoMapper
+{
+    public class CustomersProfile : Profile
+    {
+        public CustomersProfile()
+        {
+            CreateMap<Customer, CustomerData>()
+                    .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.Id))
+                    .ForMember(dest => dest.Personnummer, opt => opt.MapFrom(src => src.PIN.Text))
+                    .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name.Text));
+        }
+    }
+}

--- a/source/backend/Acerola.Infrastructure/AutoMapper/DomainConverter.cs
+++ b/source/backend/Acerola.Infrastructure/AutoMapper/DomainConverter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Acerola.Infrastructure.AutoMapper
 {
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using Acerola.Domain.Accounts;
     using Acerola.Domain.Customers;
     using global::AutoMapper;
@@ -12,37 +12,20 @@
         public DomainConverter()
         {
             Mapper.Initialize(cfg => {
-                cfg.CreateMap<Customer, CustomerVM>()
-                    .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.Id))
-                    .ForMember(dest => dest.Personnummer, opt => opt.MapFrom(src => src.PIN.Text))
-                    .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name.Text));
-
-                cfg.CreateMap<Account, AccountVM>()
-                    .ForMember(dest => dest.AccountId, opt => opt.MapFrom(src => src.Id))
-                    .ForMember(dest => dest.CurrentBalance, opt => opt.MapFrom(src => src.CurrentBalance.Value))
-                    .ForMember(dest => dest.CustomerId, opt => opt.MapFrom(src => src.CustomerId));
-
-                cfg.CreateMap<Debit, TransactionVM>()
-                    .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.Value))
-                    .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
-                    .ForMember(dest => dest.TransactionDate, opt => opt.MapFrom(src => src.TransactionDate));
-
-                cfg.CreateMap<Credit, TransactionVM>()
-                    .ForMember(dest => dest.Amount, opt => opt.MapFrom(src => src.Amount.Value))
-                    .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
-                    .ForMember(dest => dest.TransactionDate, opt => opt.MapFrom(src => src.TransactionDate));
+                cfg.AddProfile<AccountsProfile>();
+                cfg.AddProfile<CustomersProfile>();
             });
         }
 
-        public AccountVM Map(Account account)
+        public AccountData Map(Account account)
         {
-            AccountVM vm = Mapper.Map<AccountVM>(account);
+            AccountData vm = Mapper.Map<AccountData>(account);
             return vm;
         }
 
-        public CustomerVM Map(Customer customer)
+        public CustomerData Map(Customer customer)
         {
-            CustomerVM vm = Mapper.Map<CustomerVM>(customer);
+            CustomerData vm = Mapper.Map<CustomerData>(customer);
             return vm;
         }
     }

--- a/source/backend/Acerola.Infrastructure/Queries/AccountsQueries.cs
+++ b/source/backend/Acerola.Infrastructure/Queries/AccountsQueries.cs
@@ -1,7 +1,7 @@
 ﻿namespace Acerola.Infrastructure.Queries
 {
     using Acerola.Application.Queries;
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using Acerola.Domain.Accounts;
     using Acerola.Infrastructure.AutoMapper;
     using Acerola.Infrastructure.DataAccess;
@@ -21,7 +21,7 @@
             this.domainConverter = domainConverter;
         }
 
-        public async Task<AccountVM> GetAccount(Guid id)
+        public async Task<AccountData> GetAccount(Guid id)
         {
             Account data = await this.mongoDB.Accounts
                 .Find(Builders<Account>.Filter.Eq("_id", id))
@@ -30,22 +30,22 @@
             if (data == null)
                 throw new AccountNotFoundException($"The account {id} does not exists or is not processed yet.");
 
-            AccountVM accountVM = this.domainConverter.Map(data);
+            AccountData accountVM = this.domainConverter.Map(data);
 
             return accountVM;
         }
 
-        public async Task<IEnumerable<AccountVM>> GetAll()
+        public async Task<IEnumerable<AccountData>> GetAll()
         {
             IEnumerable<Account> data = await this.mongoDB.Accounts
                 .Find(e => true)
                 .ToListAsync();
 
-            List<AccountVM> result = new List<AccountVM>();
+            List<AccountData> result = new List<AccountData>();
 
             foreach (Account item in data)
             {
-                AccountVM accountVM = this.domainConverter.Map(item);
+                AccountData accountVM = this.domainConverter.Map(item);
 
                 result.Add(accountVM);
             }
@@ -53,18 +53,18 @@
             return result;
         }
 
-        public async Task<IEnumerable<AccountVM>> Get(Guid customerId)
+        public async Task<IEnumerable<AccountData>> Get(Guid customerId)
         {
             IEnumerable<Account> data = await this.mongoDB.Accounts
                 .Find(Builders<Account>
                 .Filter.Eq("CustomerId", customerId))
                 .ToListAsync();
 
-            List<AccountVM> result = new List<AccountVM>();
+            List<AccountData> result = new List<AccountData>();
 
             foreach (Account item in data)
             {
-                AccountVM accountVM = this.domainConverter.Map(item);
+                AccountData accountVM = this.domainConverter.Map(item);
 
                 result.Add(accountVM);
             }

--- a/source/backend/Acerola.Infrastructure/Queries/CustomersQueries.cs
+++ b/source/backend/Acerola.Infrastructure/Queries/CustomersQueries.cs
@@ -6,7 +6,7 @@
     using System.Threading.Tasks;
     using System.Collections.Generic;
     using Acerola.Infrastructure.DataAccess;
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using Acerola.Domain.Customers;
     using Acerola.Infrastructure.AutoMapper;
 
@@ -21,17 +21,17 @@
             this.domainConverter = domainConverter;
         }
 
-        public async Task<IEnumerable<CustomerVM>> GetAll()
+        public async Task<IEnumerable<CustomerData>> GetAll()
         {
             IEnumerable<Customer> data = await this.mongoDB.Customers
                 .Find(e => true)
                 .ToListAsync();
 
-            List<CustomerVM> result = new List<CustomerVM>();
+            List<CustomerData> result = new List<CustomerData>();
 
             foreach (Customer item in data)
             {
-                CustomerVM customerVM = this.domainConverter.Map(item);
+                CustomerData customerVM = this.domainConverter.Map(item);
 
                 result.Add(customerVM);
             }
@@ -39,7 +39,7 @@
             return result;
         }
 
-        public async Task<CustomerVM> GetCustomer(Guid id)
+        public async Task<CustomerData> GetCustomer(Guid id)
         {
             Customer data = await this.mongoDB.Customers
                 .Find(Builders<Customer>.Filter.Eq("_id", id))
@@ -48,7 +48,7 @@
             if (data == null)
                 throw new CustomerNotFoundException($"The account {id} does not exists or is not processed yet.");
 
-            CustomerVM customerVM = this.domainConverter.Map(data);
+            CustomerData customerVM = this.domainConverter.Map(data);
 
             return customerVM;
         }

--- a/source/backend/Acerola.UI/Controllers/AccountsController.cs
+++ b/source/backend/Acerola.UI/Controllers/AccountsController.cs
@@ -9,7 +9,7 @@
     using Acerola.Application.Queries;
     using Acerola.Domain.Accounts;
     using System.Collections.Generic;
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
 
     [Route("api/[controller]")]
     public class AccountsController : Controller
@@ -78,7 +78,7 @@
         [HttpGet]
         public async Task<IActionResult> List([FromQuery]Guid? customerId)
         {
-            IEnumerable<AccountVM> accounts = null;
+            IEnumerable<AccountData> accounts = null;
 
             if (customerId.HasValue)
             {

--- a/source/backend/Acerola.UI/Controllers/CustomersController.cs
+++ b/source/backend/Acerola.UI/Controllers/CustomersController.cs
@@ -2,7 +2,7 @@
 {
     using Acerola.Application.Commands.Customers;
     using Acerola.Application.Queries;
-    using Acerola.Application.ViewModels;
+    using Acerola.Application.DTO;
     using Acerola.Domain.Customers;
     using MediatR;
     using Microsoft.AspNetCore.Mvc;
@@ -36,7 +36,7 @@
         {
             Customer customer = await mediator.Send(command);
 
-            CustomerVM result = new CustomerVM
+            CustomerData result = new CustomerData
             {
                 CustomerId = customer.Id,
                 Name = customer.Name.Text,
@@ -52,7 +52,7 @@
         [HttpGet("{id}", Name = "GetCustomer")]
         public async Task<IActionResult> GetCustomer(Guid id)
         {
-            CustomerVM customer = await customersQueries.GetCustomer(id);
+            CustomerData customer = await customersQueries.GetCustomer(id);
 
             return Ok(customer);
         }
@@ -63,7 +63,7 @@
         [HttpGet]
         public async Task<IActionResult> Get()
         {
-            IEnumerable<CustomerVM> customers = await customersQueries.GetAll();
+            IEnumerable<CustomerData> customers = await customersQueries.GetAll();
 
             return Ok(customers);
         }

--- a/source/backend/Acerola.UnitTests/IntegrationTests.cs
+++ b/source/backend/Acerola.UnitTests/IntegrationTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Acerola.UnitTests
 {
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.TestHost;
-    using Xunit;
-
     class IntegrationTests
     {
     }


### PR DESCRIPTION
Changing names of DTOs to Data instead of VM. VM is more likely to be used with MVVM or MVC pattern